### PR TITLE
feat: signup > auth Page

### DIFF
--- a/email.json
+++ b/email.json
@@ -11,6 +11,27 @@
     {
       "email": "asdf@gmail.com",
       "id": 3
+    },
+    {
+      "email": "jhyeom95@gmail.com",
+      "id": 4
+    },
+    {
+      "email": "jhyeom95@naver.com",
+      "id": 5
+    },
+    {
+      "email": "jhyeom95@nate.com",
+      "id": 6
+    },
+    {
+      "email": "jhyeom95@daum.com",
+      "id": 7
+    }
+  ],
+  "auth": [
+    {
+      "number": "123456"
     }
   ]
 }

--- a/pages/main/index.tsx
+++ b/pages/main/index.tsx
@@ -35,7 +35,7 @@ const Main:React.FC = () => {
                         />
                             <SC.Spinner>
                             <svg className={`${isAnimating ? 'spinner' : ''}`} width="42px" height="42px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" stroke-width="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
+                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" strokeWidth="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
                                 </svg>
                             </SC.Spinner>
                         <SC.StoryID>정호다</SC.StoryID>
@@ -50,7 +50,7 @@ const Main:React.FC = () => {
                         />
                             <SC.Spinner>
                             <svg className={`${isAnimating ? 'spinner' : ''}`} width="42px" height="42px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" stroke-width="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
+                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" strokeWidth="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
                                 </svg>
                             </SC.Spinner>
                         <SC.StoryID>정호다</SC.StoryID>
@@ -65,7 +65,7 @@ const Main:React.FC = () => {
                         />
                             <SC.Spinner>
                             <svg className={`${isAnimating ? 'spinner' : ''}`} width="42px" height="42px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" stroke-width="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
+                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" strokeWidth="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
                                 </svg>
                             </SC.Spinner>
                         <SC.StoryID>정호다</SC.StoryID>
@@ -80,7 +80,7 @@ const Main:React.FC = () => {
                         />
                             <SC.Spinner>
                             <svg className={`${isAnimating ? 'spinner' : ''}`} width="42px" height="42px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" stroke-width="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
+                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" strokeWidth="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
                                 </svg>
                             </SC.Spinner>
                         <SC.StoryID>정호다</SC.StoryID>
@@ -95,7 +95,7 @@ const Main:React.FC = () => {
                         />
                             <SC.Spinner>
                             <svg className={`${isAnimating ? 'spinner' : ''}`} width="42px" height="42px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" stroke-width="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
+                                    <circle className={`${isAnimating ? 'path' : ''}`} fill="none" strokeWidth="6" strokeLinecap="round" cx="33" cy="33" r="30"></circle>
                                 </svg>
                             </SC.Spinner>
                         <SC.StoryID>정호다</SC.StoryID>

--- a/pages/signup/auth.tsx
+++ b/pages/signup/auth.tsx
@@ -1,8 +1,0 @@
-const Auth: React.FC = () => {
-    return(
-    <>
-    </>
-    )
-}
- 
-export default Auth

--- a/pages/signup/auth/index.tsx
+++ b/pages/signup/auth/index.tsx
@@ -1,0 +1,73 @@
+import * as SC from './styled'
+import React, { useEffect, useState} from 'react';
+import { faChevronLeft} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import axios from 'axios';
+import {useRouter} from 'next/router';
+
+const Auth: React.FC = () => {
+    const router = useRouter()
+    const [email, setEmail] = useState('')
+    const [authNumber, setAuthNumber] = useState('')
+
+    useEffect(() => {
+        axios.get('http://localhost:5000/email')
+        .then((response) => {
+            const data = response.data
+            const selectedEmail = data[data.length - 1].email
+            setEmail(selectedEmail)
+        }).catch((error) =>
+            console.log(error)
+        )
+    })
+
+    const inputHandler = (e:React.ChangeEvent<HTMLInputElement>) => {
+        setAuthNumber(e.target.value)
+    }
+
+    const submitHandler = () => {
+        if(authNumber === ''){
+            alert('인증번호를 입력해주세요')
+        }else{
+            axios.get('http://localhost:5000/auth')
+            .then((response) => {
+                const data = response.data[0].number
+                console.log(data)
+                if(authNumber === data){
+                    alert('인증되었습니다.')
+                    router.push('/signup/details')
+                }else{
+                    alert('인증번호가 맞지 않습니다.')
+                }
+            })
+        }
+    }
+
+
+    return(
+        <>
+        <SC.Header>
+            <FontAwesomeIcon icon={faChevronLeft}/>
+            <span>등록</span>
+            <span></span>
+        </SC.Header>
+        <SC.Container>
+            <SC.Contents>
+                <SC.Title>인증코드 입력</SC.Title>
+                <SC.Descriptions>
+                    {email} 주소로 전송된 인증 코드를 입력하세요. 
+                    <span style={{color: 'blue'}}>코드 재전송</span>
+                </SC.Descriptions>
+                <SC.AuthInput 
+                type="number" placeholder='인증번호를 입력하세요'
+                onChange={inputHandler}
+                value={authNumber}
+                ></SC.AuthInput>
+                    <SC.SubmitButton onClick={submitHandler}>다음</SC.SubmitButton>
+            </SC.Contents>
+        </SC.Container>
+        </>
+    )
+}
+ 
+export default Auth

--- a/pages/signup/auth/styled.ts
+++ b/pages/signup/auth/styled.ts
@@ -1,0 +1,60 @@
+import { styled } from "styled-components"
+
+
+export const Container = styled.section`
+    width: 100%;
+    height: 95vh;
+    color: black;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`
+
+export const Header = styled.header`
+    width: 100%;
+    height: 5vh;
+    color: black;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 20px;
+    font-size: 15px;
+`
+
+export const Contents = styled.div`
+    width: 90%;
+    height: 80%;
+    display: flex;
+    flex-direction: column;
+`
+
+export const Title = styled.h2`
+    font-size: 20px;
+    text-align: center;
+    margin-bottom: 30px;
+`
+
+export const Descriptions = styled.p`
+    text-align: center;
+    font-size: 15px;
+    margin-bottom: 10px;
+`
+
+
+export const AuthInput = styled.input`
+    background-color: gainsboro;
+    border: none;
+    border-radius: 10px;
+    height: 45px;
+    color: black;
+    font-size: 20px;
+    margin-bottom: 10px;
+`
+
+export const SubmitButton = styled.button`
+    height: 45px;
+    background-color: blue;
+    border: none;
+    border-radius: 10px;
+    font-size: 20px;
+`

--- a/pages/signup/details/index.tsx
+++ b/pages/signup/details/index.tsx
@@ -1,0 +1,5 @@
+const Details = () => {
+
+}
+
+export default Details

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -32,7 +32,6 @@ const Signup: React.FC = () => {
             .then((response) => {
                 const data = response.data
                 const filtered = data.filter((v: any) => v.email === email)
-                console.log(filtered)
                 if(filtered.length === 0){
                     axios.post('http://localhost:5000/email', {email: `${email}`})
                     .then(() => {


### PR DESCRIPTION
## Motivations 😀

- ​signup 페이지의 auth 페이지 (인증 번호 확인)페이지 레이아웃 및 axios로 json-server의 샘플 데이터로 인증 확인 후 다음 페이지로 넘어가게끔 구현
  <br/>
  ​

## key Changes 🤩

- ​auth 확인
- 인증받을 이메일은 백엔드와 연동후에 response로 받을 예정
- 현재는 가장 마지막에 등록한 이메일을 인증할 이메일로 지정
  <br/>
  ​

## To Reviewers 😎

- ​
  <br/>
