### PR TITLE
styled-components SSR 방지

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,13 @@
+{
+    "presets": ["next/babel"],
+    "plugins": [
+      [
+        "styled-components",
+        {
+          "ssr": true,
+          "displayName": true,
+          "preprocess": false
+        }
+      ]
+    ]
+  }

--- a/pages/_documnet.tsx
+++ b/pages/_documnet.tsx
@@ -1,0 +1,49 @@
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+} from "next/document";
+import { ServerStyleSheet } from "styled-components";
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head></Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;


### PR DESCRIPTION
## Motivations 😀

- ​styled-components를 통해 페이지를 만들다 보면 페이지를 불러올 때 HTML 만 가져오고, 스타일이 적용되어있지 않다. 위 코드를 추가해줘야만 서버 사이드 렌더링 시 styled-components가 헤더에 주입된다. 즉 서버에서 미리 HTML을 마크업할 때 스타일까지 HTML 요소에 녹여내는 것이다.
이를 _document.tsx가 수행한다.

- 최초 서버 사이드에서 렌더링 이후 클라이언트 사이드 렌더링으로 라우팅을 하게 된다. 이 때 서버에서 생성하는 해시값과 브라우저에서 생성하는 해시값이 서로 달라 에러가 발생하게 된다.(Prop className did not match)
- 이를 방지하기 위해 styled-components 바벨 플러그인을 설치한다.

- https://mniyunsu.github.io/nextjs-styled-component-setting/
  <br/>
  ​

## key Changes 🤩
- ​SSR되어 HTML만 불러오던 문제 해결
- 이제 새로고침 해도 CSS가 잘 불러와짐
- document.tsx는 추후에 SEO를 위해 채워넣을 예정


  <br/>
  ​

## To Reviewers 😎

- ​yarn install 바람!
  <br/>
