### PR TITLE
fix: reels 오버스크롤 시 돌아오기

### DIFF
--- a/pages/reels/index.tsx
+++ b/pages/reels/index.tsx
@@ -11,27 +11,31 @@ import  { useState , useEffect, useRef } from 'react'
 
 const Reels: React.FC = () => {
     const containerRef = useRef<HTMLElement | null>(null);
-    let [count, setCount] = useState(0)
-    let [startY, setStartY] = useState(0)
+    const [count, setCount] = useState(0)
+    const [startY, setStartY] = useState(0)
+    const [articles] = useState(2)
     useEffect(() => {
         const container = containerRef.current;
         if (container) {
-          container.scrollTo({ top: 870 * count, behavior: 'smooth' });
+            container.scrollTo({ top: 870 * count, behavior: 'smooth' });
         }
       }, [count]);
+
+      
     
       const handleTouchStart = (e:React.TouchEvent) => {
-        setStartY(e.touches[0].clientY)
+          setStartY(e.touches[0].clientY)
       }
 
       const handleTouchEnd = (e:React.TouchEvent) => {
         if(startY > e.changedTouches[0].clientY){
-            setCount((prev) => prev + 1)
+            console.log(e)
+            setCount((prev) => prev === articles ? prev : prev + 1 )
         }else if(startY < e.changedTouches[0].clientY){
-            setCount((prev) => prev - 1)
+            setCount((prev) => prev === 0 ? prev : prev - 1)
         }
     }
-
+    
 
     return (
         <>


### PR DESCRIPTION
## Motivations 😀

- ​reels 오버 스와이프 발생 시 페이지가 핏하게 안 넘어가는데 setTimeout으로 0.3초에 간격을 두어 스와이프때마다 잔여 스크롤을 모두 실행하고 애니메이션 실행하게끔 해법을 찾았습니다.
  <br/>
  ​

## key Changes 🤩

- 스크롤 실행 후 비동기로 애니메이션 실행
  <br/>
  ​

## To Reviewers 😎

- ​마음에 드는 해법은 아닌데 일단 머지하겠슴다 ㅠㅠ
  <br/>
