### PR TITLE
Fix: direct-page 이미지 업로드 에러

### DIFF
--- a/components/input/DirectMessage/DirectMessage.tsx
+++ b/components/input/DirectMessage/DirectMessage.tsx
@@ -4,9 +4,13 @@ import { faImage, faTimesCircle } from "@fortawesome/free-regular-svg-icons";
 
 interface DirectMessageProps {
   onMessageSend: (message: string, images: File[], imageUrls: string[]) => void;
+  selectedImages: File[];
 }
 
-const DirectMessage: React.FC<DirectMessageProps> = ({ onMessageSend }) => {
+const DirectMessage: React.FC<DirectMessageProps> = ({
+  onMessageSend,
+  selectedImages,
+}) => {
   const [message, setMessage] = useState<string>("");
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -31,8 +35,10 @@ const DirectMessage: React.FC<DirectMessageProps> = ({ onMessageSend }) => {
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
-    const fileList = Array.from(files);
-    setSelectedFiles([...selectedFiles, ...fileList]);
+    if (files) {
+      const fileList = Array.from(files);
+      setSelectedFiles([...selectedFiles, ...fileList]);
+    }
   };
 
   const handleRemove = (index: number) => {

--- a/pages/direct/in/[id].tsx
+++ b/pages/direct/in/[id].tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import axios from "axios";
-import DirectInHeader from "../../../components/atoms/DirectInHeader";
-import DirectPartner from "../../../components/atoms/DirectPartner";
+import DirectInHeader from "@/components/atoms/DirectInHeader";
+import DirectPartner from "@/components/atoms/DirectPartner";
 import DirectMessage from "@/components/input/DirectMessage/DirectMessage";
 import DmContentsList from "@/components/list/DmContentsList";
 
@@ -20,9 +20,19 @@ const In: React.FC = () => {
   const router = useRouter();
   const { id } = router.query;
 
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
   const handleSendMessage = (message: string, images: File[]) => {
     setMessages([...messages, message]);
-    setSelectedImages(images);
+    setSelectedImages((prevSelectedImages) => [
+      ...prevSelectedImages,
+      ...images,
+    ]);
+
+    if (contentRef.current) {
+      contentRef.current.scrollTop = contentRef.current.scrollHeight;
+      contentRef.current.focus();
+    }
     console.log(`전달된 메시지: ${message}`);
   };
 
@@ -45,8 +55,15 @@ const In: React.FC = () => {
         <>
           <DirectInHeader selectedItem={partner} />
           <DirectPartner selectedItem={partner} />
-          <DmContentsList messages={messages} selectedImages={selectedImages} />
-          <DirectMessage onMessageSend={handleSendMessage} />
+          <DmContentsList
+            messages={messages}
+            selectedImages={selectedImages}
+            contentRef={contentRef}
+          />
+          <DirectMessage
+            onMessageSend={handleSendMessage}
+            selectedImages={selectedImages}
+          />
         </>
       )}
     </>

--- a/utils/fileToDataUrl.ts
+++ b/utils/fileToDataUrl.ts
@@ -1,0 +1,16 @@
+export const fileToDataUrl = async (file: File): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Unable to read the file as a data URL."));
+      }
+    };
+    reader.onerror = (error) => {
+      reject(error);
+    };
+    reader.readAsDataURL(file);
+  });
+};


### PR DESCRIPTION
## Motivations 😀

- ​다이렉트 페이지에 이미지를 업로드 하려는데 타입을 File로 준 걸 string으로 변환하라는 에러가 발생
- 새로운 이미지, 메세지를 띄우는데 스크롤 포커스가 맞춰지지 않음
- useRef가 작동은 되는 거 같은데 제일 최근 메세지 바로 이전 요소에 포커스가 맞춰지는 오류 발생
  <br/>
  ​

## key Changes 🤩

- 로컬에서 이미지 미리보기와 이미지 업로드를 하기 위해서는 이미지를 Data URL로 변환해야 해서 해당 관련 함수 추가
- ​useRef로 스크롤 포커스 되도록 조건 추가
- 이후에 발생한 오류에서는 의존성에 모든 요소 포함해서 새롭게 변경된 값을 감지해서 스크롤 포커스 적용되도록 수정 후 오류 해결함
  <br/>
  ​

## To Reviewers 😎

- ​이미지와 메세지 시간 순으로 배열해서 렌더링 하고 싶은데 이 부분은 아직 진행 중입니다~~
  <br/>
