### PR TITLE
Fix: search-page 검색 리스트 렌더링 오류

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -74,7 +74,9 @@ const Header: React.FC<HeaderProps> = (props) => {
 
   return (
     <Container>
-      <Title>Inssagram</Title>
+      <Title>
+        <Link href="/">Inssagram</Link>
+      </Title>
       <IconPannels>
         <PlusBtn id="createBoards" onClick={createBoards}>
           <FontAwesomeIcon icon={faSquarePlus} fontSize={"24px"} />

--- a/components/list/SearchList/SearchList.tsx
+++ b/components/list/SearchList/SearchList.tsx
@@ -17,11 +17,13 @@ interface Item {
 
 const SearchList: React.FC<{ searchTerm: string }> = ({ searchTerm }) => {
   const [results, setResults] = useState<Item[]>([]);
+  console.log(results);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (searchTerm) {
-      setIsLoading(false);
+      setIsLoading(true);
+
       axios
         .get<Item[]>(`http://localhost:3001/accounts`)
         .then((response) => response.data)
@@ -37,14 +39,7 @@ const SearchList: React.FC<{ searchTerm: string }> = ({ searchTerm }) => {
           console.error("데이터를 불러오는 중 오류 발생:", error);
           setIsLoading(false);
         });
-    } else {
-      setResults([]);
-    }
-  }, [searchTerm]);
 
-  useEffect(() => {
-    if (searchTerm) {
-      setIsLoading(false);
       axios
         .get<Item[]>(`http://localhost:3001/hashtags`)
         .then((response) => response.data)
@@ -53,7 +48,7 @@ const SearchList: React.FC<{ searchTerm: string }> = ({ searchTerm }) => {
             (item) =>
               item.type === "hashtag" && item.name.startsWith(searchTerm)
           );
-          setResults(filteredResults);
+          setResults((prevResults) => [...prevResults, ...filteredResults]);
           setIsLoading(false);
         })
         .catch((error) => {


### PR DESCRIPTION
## Motivations 😀

![search-page error](https://github.com/inssagram/FE/assets/123256640/d57d0193-21d2-47ac-8e12-f39615cc6a12)
- 두 군데서 데이터를 불러오기 위해서 useEffect를 두 개 작성했더니 searchTerm이 변경될 때 두 개의 useEffect가 독립적으로 작동해 결과가 서로 다르게 나오는 오류가 생긴 것으로 여겨짐
  <br/>
  ​

## key Changes 🤩

- ​searchTerm 으로 입력 값을 먼저 받아 값이 변경되면 두 개의 엔드포인트에서 데이터를 비교하여 하나의 결과를 배열에 저장하도록 코드 수정
  <br/>
  ​

## To Reviewers 😎

- ​움짤 만들어봤는데 화질 똥이라 죄송합니다..
  <br/>
