### PR TITLE
feat: DM in story page , fix: z-index => display: none

### DIFF
--- a/components/styled/story.ts
+++ b/components/styled/story.ts
@@ -66,6 +66,11 @@ export const BarCovering = keyframes`
 interface BarProps {
     isAnimating: boolean;
     isComplete: boolean;
+    animationStopped: boolean;
+}
+
+interface filterProps {
+    onFilter: boolean ;
 }
 
 export const BarCover = styled.div<BarProps>`
@@ -86,6 +91,7 @@ export const BarCover = styled.div<BarProps>`
       width: 100%;
       animation: none; // 애니메이션 제거
     `}
+    animation-play-state: ${(props) => (props.animationStopped ? "paused" : 'running')};
 `;
 
 
@@ -132,26 +138,53 @@ export const Contents = styled.div`
 
 
 // ----------------------------------------------------------------------------
-export const Comment = styled.div`
+export const Comment = styled.div<filterProps>`
     position: absolute;
     width: 100%;
     bottom: 0;
     height: 40px;
-    display: flex;
+    display: ${(props) => (props.onFilter ? 'none' : 'flex')};
     align-items: center;
     justify-content: space-around;
     margin-bottom: 10px;
+
 `
 
-export const TextArea = styled.input`
-    color: white;
+export const TextBox = styled.div`
+    display: flex;
+    align-items: center;
+    color: gray;
     border-radius: 50px;
     width: 70%;
     border: 2px white solid;
     height: 100%;
     background-color: transparent;
-    ::placeholder {
-    color: deepPink;
-  }
-  padding-left: 15px;
+    padding-left: 15px;
+`
+
+// --------------------------
+
+export const DMfilter = styled.section<filterProps>`
+    display: ${(props) => (props.onFilter ? 'flex' : 'none')};
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    background-color: rgba(0,0,0,0.3);
+    top: 0;
+    position: absolute;
+    z-index: 10;
+    width: 100%;
+    height: 100%;
+`
+
+export const TextArea = styled.input`
+    position: absolute;
+    bottom: 0;
+    border-radius: 50px;
+    width: 95%;
+    border: 3px white solid;
+    height: 40px;
+    background-color: transparent;
+    padding-left: 15px;
+    margin-bottom: 10px;
 `

--- a/pages/story/index.tsx
+++ b/pages/story/index.tsx
@@ -16,6 +16,9 @@ const Story: React.FC = () => {
   const [imagesIndexArr, setImagesIndexArr] = useState<number[]>([]);
   const [flag, toggleFlag] = useState(false);
   const [availableIndex, setAvailableIndex] = useState<number[]>([]);
+  const [onFilter, setOnFilter] = useState(false)
+  const [animationStopped, setAnimationStopped] = useState(false)
+  
 
   interface dataItem{
     id: number,
@@ -30,9 +33,9 @@ const Story: React.FC = () => {
   }
 
   const Cube: React.FC<cubesItem> = ({ index }) => (
-    <SC.Article 
-      style={{ transform: `rotateY(${index * 90}deg) translateZ(calc(100vw / 2))`, zIndex: availableIndex.includes(index) ? 10 : 0}} 
-    >
+      <SC.Article 
+        style={{ transform: `rotateY(${index * 90}deg) translateZ(calc(100vw / 2))`, display: availableIndex.includes(index) ? "block" : "none"}} 
+      >
           <SC.ProgressBars>
             {data[index].image.map((_, i) => {
                 return(
@@ -41,6 +44,7 @@ const Story: React.FC = () => {
                       isComplete={imagesIndexArr[index] > i} 
                       isAnimating={imagesIndexArr[index] === i}
                       onAnimationEnd={flagHandler}
+                      animationStopped={animationStopped}
                       ></SC.BarCover>
                     </SC.Bar>
                   )
@@ -70,11 +74,29 @@ const Story: React.FC = () => {
               fill={true}
             />
           </SC.Contents>
-          <SC.Comment>
-            <SC.TextArea placeholder="메시지를 입력하세요" onClick={(e) => e.stopPropagation()}></SC.TextArea>
+          <SC.Comment onFilter={onFilter}>
+          <SC.TextBox onClick={() => {
+            setOnFilter(true)
+            setAnimationStopped(true)
+          }}>메시지를 입력하세요</SC.TextBox>
             <FontAwesomeIcon icon={faHeart} fontSize={"25px"} />
             <FontAwesomeIcon icon={faPaperPlane} fontSize={"25px"} />
           </SC.Comment>
+          <SC.DMfilter onClick={() => {
+            setOnFilter(false)
+            setAnimationStopped(false)
+          }}
+          onFilter={onFilter}>
+            <SC.TextArea 
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if(e.key === "Enter"){
+                  setOnFilter(false)
+                  setAnimationStopped(false)
+                }
+              }}
+            ></SC.TextArea>
+          </SC.DMfilter>
         </SC.Article>
   )
   
@@ -119,7 +141,6 @@ const Story: React.FC = () => {
     .then((response) => {
       setData(response.data)
     }).then(() => {
-      console.log(imagesIndexArr)
     }).catch((error) => {
       console.log(error)
     })
@@ -129,7 +150,6 @@ const Story: React.FC = () => {
     setImagesIndexArr(Array(data.length).fill(0))
   },[data])
   
-  console.log(imagesIndexArr)
   useEffect(() => {
     setAvailableIndex([contentsIndex - 1, contentsIndex, contentsIndex + 1])
   },[contentsIndex])
@@ -160,6 +180,8 @@ const Story: React.FC = () => {
   }, [flag,imagesIndexArr]);
 
 
+  const handleSendDM = () => {
+  }
  
   if(data.length !== 0){
   return (


### PR DESCRIPTION
## Motivations 😀

- 인스타그램 ​스토리 페이지에서 DM을 보낼떄 배경이 흐릿해지는 필터 모달이 들어가는것을 보고 구현
- 이모지를 넣는것도 있는데 고것은 차차 넣어볼게요!
- DM을 보낼때 뒤에 자동으로 스토리가 넘어가는 애니메이션과 기능을 잠시 멈추게 만들었습니다
- 다만, 일시정지를 하고싶은데 정지가 되어버려서 이건 차차 해볼게요 하루종일 했는데 안되네 ㅠㅠ
-
- 그리고 이미지 바뀔때 뒷 이미지가 먼저 나오는 버그가 있었는데 `display: none`으로 안보이게 처리 했습니당
- 채팅이 구현되면 소켓으로 연결해서 텍스트를 보내기만 하는 용도로 사용해볼 예정!
  <br/>
  ​

## key Changes 🤩

- ​스토리 페이지에서 DM보내기
  <br/>
  ​

## To Reviewers 😎

-
![ezgif com-crop](https://github.com/inssagram/FE/assets/105287510/b39dd8cd-4d8d-473a-8135-8453920bb742)
  <br/>
