### PR TITLE
reafactor: firebase auth 로직 삭제, Post 생성 후 생성된 게시글로 이동

### DIFF
--- a/components/firebase/firebase.ts
+++ b/components/firebase/firebase.ts
@@ -1,6 +1,5 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
@@ -16,5 +15,4 @@ const firebaseConfig = {
 
 const firebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
-export const auth = getAuth(firebaseApp);
 export const storage = getStorage(firebaseApp);

--- a/pages/create/details/index.tsx
+++ b/pages/create/details/index.tsx
@@ -57,15 +57,20 @@ const Details: React.FC = () => {
       "image": [imageBlob],
       "contents": contents,
     }
-    return axiosInstance({
-      method: "post",
-      url: "/post/create",
-      headers: {
-        "Content-Type": "application/json",
-        charset: "utf-8",
-      },
-      data: postData,
-    });
+    try{
+      const res = await axiosInstance({
+        method: "post",
+        url: "/post/create",
+        headers: {
+          "Content-Type": "application/json",
+          charset: "utf-8",
+        },
+        data: postData,
+      });
+      return res.data.postId
+    }catch(error){
+      console.error(error)
+    }
   };
 
   const handleCreateBoard = async () => {
@@ -77,7 +82,8 @@ const Details: React.FC = () => {
         const blobImage = await uploadTask;
         const downloadURL = await getDownloadURL(blobImage.ref);
         await uploadImageToServer(downloadURL, contents)
-        console.log('downloadURL:',downloadURL, 'uuid:',uuid,)
+        const postId = await uploadImageToServer(downloadURL, contents)
+        router.push(`/my/feeds/${postId}`)
      }
     }catch (error) {
       console.error(error);

--- a/pages/signup/job/index.tsx
+++ b/pages/signup/job/index.tsx
@@ -6,8 +6,6 @@ import { BackArrow } from "@/components/atoms/Icon";
 import { reduceJob } from "../emailState";
 import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
-import { auth } from "@/components/firebase/firebase";
-import { createUserWithEmailAndPassword } from "firebase/auth";
 
 
 const Job = () => {
@@ -68,7 +66,6 @@ const Job = () => {
   const submitButtonHandler = async () => {
     try{
       await dispatch(reduceJob(inputValue))
-      await createUserWithEmailAndPassword(auth, register.email, register.password)
       await axios.post(`${BASE_URL}/signup`, {
         email: register.email,
         password: register.password,


### PR DESCRIPTION
## Motivations 😀

- ​계속되는 서버 리셋 작업으로 파이어베이스와 유저 정보 동기화가 제대로 되지 않음
- 파이어베이스 유저 정보 없이 스토리지에 접근할 수 있게 허용
- 서버 리셋 되어도 이제 맘껏 회원가입 가능!

===================================

- 이제 post하고 생성된 게시물로 바로 이동합니다!
- 업로드 시간이 좀 걸려서 페이지 안넘어간다고 공유하기 마구마구 누르면 게시글 여러개 생성될 수 있음!

  <br/>
  ​

## key Changes 🤩

- ​firebase auth 로직 삭제, Post 생성 후 생성된 게시글로 이동
  <br/>
  ​

## To Reviewers 😎

- ​
  <br/>
