### PR TITLE
Fix: searchBar 렌더링 오류 수정

### DIFF
--- a/components/Chat/AccountList.tsx
+++ b/components/Chat/AccountList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, Dispatch, SetStateAction } from "react";
 import Image from "next/image";
 import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -15,42 +15,59 @@ interface AccountData {
 interface AccountListProps {
   searchResults: AccountData[];
   onSelectAccount: (selectedAccount: AccountData) => void;
+  isAccountSelected: boolean;
+  setIsAccountSelected: Dispatch<SetStateAction<boolean>>;
 }
 
 const AccountList: React.FC<AccountListProps> = ({
   searchResults,
   onSelectAccount,
+  isAccountSelected,
+  setIsAccountSelected,
 }) => {
   const handleSelectAccount = (selectedAccount: AccountData) => {
     onSelectAccount(selectedAccount);
+    setIsAccountSelected(true);
   };
+
+  useEffect(() => {
+    setIsAccountSelected(false);
+  }, [setIsAccountSelected]);
 
   return (
     <>
-      {searchResults && searchResults.length > 0 ? (
-        searchResults.map((result, index) => (
-          <ResultContainer key={index}>
-            <Profile>
-              <Image
-                src={result.image ? result.image : "/images/noProfile.jpg"}
-                alt="프로필"
-                width={44}
-                height={44}
-              />
-            </Profile>
-            <Account>
-              <Name>{result.nickName}</Name>
-              <Follow>{result.friendStatus ? "팔로잉" : ""}</Follow>
-            </Account>
-            <SelectBtn onClick={() => handleSelectAccount(result)}>
-              <Icon icon={faCircleCheck} fontSize={"24px"} />
-            </SelectBtn>
-          </ResultContainer>
-        ))
-      ) : (
+      {isAccountSelected ? (
         <ResultsList>
-          <Results>계정을 찾을 수가 없습니다.</Results>
+          <Results>대화 상대를 검색해보세요.</Results>
         </ResultsList>
+      ) : (
+        <>
+          {searchResults && searchResults.length > 0 ? (
+            searchResults.map((result, index) => (
+              <ResultContainer key={index}>
+                <Profile>
+                  <Image
+                    src={result.image ? result.image : "/images/noProfile.jpg"}
+                    alt="프로필"
+                    width={44}
+                    height={44}
+                  />
+                </Profile>
+                <Account>
+                  <Name>{result.nickName}</Name>
+                  <Follow>{result.friendStatus ? "팔로잉" : ""}</Follow>
+                </Account>
+                <SelectBtn onClick={() => handleSelectAccount(result)}>
+                  <Icon icon={faCircleCheck} fontSize={"24px"} />
+                </SelectBtn>
+              </ResultContainer>
+            ))
+          ) : (
+            <ResultsList>
+              <Results>계정을 찾을 수가 없습니다.</Results>
+            </ResultsList>
+          )}
+        </>
       )}
     </>
   );

--- a/components/Chat/SearchInput.tsx
+++ b/components/Chat/SearchInput.tsx
@@ -11,15 +11,16 @@ interface AccountData {
 
 interface SearchInputProps {
   onSearch: (searchValue: string) => void;
-  selectedAccount: AccountData[];
+  selectedAccount: AccountData | null;
+  isAccountSelected: boolean;
 }
 
 const SearchInput: React.FC<SearchInputProps> = ({
   onSearch,
   selectedAccount,
+  isAccountSelected,
 }) => {
   const [searchValue, setSearchValue] = useState("");
-  console.log(searchValue);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -27,20 +28,28 @@ const SearchInput: React.FC<SearchInputProps> = ({
     onSearch(value);
   };
 
+  useEffect(() => {
+    if (isAccountSelected) {
+      setSearchValue("");
+    }
+  }, [isAccountSelected]);
+
   return (
     <>
       <SearchBarContainer>
         <Title>받는 사람:</Title>
-        {selectedAccount && selectedAccount.length > 0 && (
+        {selectedAccount && selectedAccount.nickName && (
           <SelectedAccount>
             <Tag>
-              <Name>{selectedAccount[0].nickName}</Name>
+              <Name>
+                {selectedAccount.nickName ? selectedAccount.nickName : ""}
+              </Name>
             </Tag>
           </SelectedAccount>
         )}
         <Input
           type="text"
-          placeholder="검색..."
+          placeholder={"검색..."}
           value={searchValue}
           onChange={handleInputChange}
         />

--- a/components/atoms/SearchBar.tsx
+++ b/components/atoms/SearchBar.tsx
@@ -34,7 +34,7 @@ const SearchBar: React.FC<{ onSearch: (searchValue: string) => void }> = ({
 
   useEffect(() => {
     onSearch(searchValue);
-  }, [searchValue]);
+  }, [onSearch, searchValue]);
 
   return (
     <SearchBarContainer>

--- a/pages/explore/index.tsx
+++ b/pages/explore/index.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { handleError } from "@/utils/errorHandler";
-import SearchBar from "@/components/input/SearchBar";
+import SearchBar from "@/components/atoms/SearchBar";
 import Footer from "@/components/Footer";
 import getPostAllAxios from "@/services/postInfo/getPostAll";
 

--- a/pages/explore/search/index.tsx
+++ b/pages/explore/search/index.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { handleError } from "@/utils/errorHandler";
 import { SearchHistoryHeader } from "@/components/atoms/Header";
 import { SearchItem } from "@/components/atoms/Item";
-import SearchBar from "@/components/input/SearchBar";
+import SearchBar from "@/components/atoms/SearchBar";
 import Footer from "@/components/Footer";
 import getSearchResultAxios from "@/services/searchInfo/getSearchResult";
 import getSearchHistoryAxios from "@/services/searchInfo/getSearchHistory";
@@ -84,6 +84,8 @@ const Search: React.FC = () => {
   useEffect(() => {
     if (searchTerm) {
       fetchSearchResultData(searchTerm);
+    } else {
+      setSearchResults([]);
     }
   }, [searchTerm]);
 
@@ -102,7 +104,8 @@ const Search: React.FC = () => {
             />
           ))}
         {searchResults.length > 0 ? "" : <SearchHistoryHeader />}
-        {searchHistory.length > 0 ? (
+        {searchHistory.length > 0 &&
+          !searchTerm &&
           searchHistory.map((history, index) => (
             <SearchItem
               key={index}
@@ -110,8 +113,8 @@ const Search: React.FC = () => {
               handleDelete={() => handleSearchItemDeleteClick(history.searched)}
               isHistory
             />
-          ))
-        ) : (
+          ))}
+        {!searchResults.length && !searchHistory.length && (
           <NoHistory>최근 검색 기록이 없습니다.</NoHistory>
         )}
       </Container>


### PR DESCRIPTION
## Motivations 😀

1. SearchInput에 검색어를 입력 시 최근 검색 기록과 검색 결과 리스트가 함께 보이고 있음(x 버튼이 있는 컴포넌트)

![image](https://github.com/inssagram/FE/assets/123256640/317a3591-9883-4d18-a84f-4b6463484713)

1. SearchInput에 입력 값이 없는데도 검색 결과 리스트를 조회하고있음(이전 검색 이력이 감지된 후 초기화 되지 않음)

![image](https://github.com/inssagram/FE/assets/123256640/0724e752-5f86-4679-8fff-c3e8cadd445c)

2. 대화 상대를 선택 한 후 SearchInput에 memberNickname을 props로 전달해 표시를 하는데 이전 검색값이 지워지지 않는 오류(yuri를 검색해서 해당 검색 결과 가져왔는데 yuri가 초기화되지 않고 유지됨)

![image](https://github.com/inssagram/FE/assets/123256640/a16d2378-12ff-4c15-bccb-9b95ca9a1646)
  <br/>
  ​

## key Changes 🤩

1. ​isSelectedAccount에 boolean 값을 부여하여 검색 페이지에서는 좀 더 확실한 조건에 데이터를 렌더링할 수 있도록 하였고, SearchInput에서 입력 값을 감지하고있는 searchTerm에 값이 지워지면 초기화 되도록 하는 코드를 추가

2. 이전 머지에서 selectedAccount에서 배열로 담고있는 부분 타입 정의 string으로 수정 진행했고, 검색페이지와 마찬가지로 입력값이 지워지면 SearchInput에 담긴 값 초기화 되도록 코드 추가
  <br/>
  ​

## To Reviewers 😎

- ​
  <br/>
