### PR TITLE
feat: add resizer func

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-helmet": "^6.1.0",
+    "react-image-file-resizer": "^0.4.8",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.16.0",
     "redux": "4",

--- a/pages/create/details/handleResizeImage.ts
+++ b/pages/create/details/handleResizeImage.ts
@@ -1,0 +1,17 @@
+import Resizer from "react-image-file-resizer";
+
+export const handleResizeImage = (file: any) =>
+    new Promise((res) => {
+      Resizer.imageFileResizer(
+        file, // target file
+        1500, // maxWidth
+        1500, // maxHeight
+        "JPEG", // compressFormat : Can be either JPEG, PNG or WEBP.
+        80, // quality : 0 and 100. Used for the JPEG compression
+        0, // rotation
+        (uri) => res(uri), // responseUriFunc
+        "file" // outputType : Can be either base64, blob or file.(Default type is base64)	
+      );
+    });
+
+    // https://github.com/onurzorluer/react-image-file-resizer

--- a/pages/create/details/index.tsx
+++ b/pages/create/details/index.tsx
@@ -18,6 +18,7 @@ import { v4 as uuidv4} from "uuid"
 import { ref,uploadBytes,getDownloadURL } from "firebase/storage";
 import { storage } from "@/components/firebase/firebase";
 import axiosInstance from "@/services/axiosInstance";
+import { handleResizeImage } from "./handleResizeImage";
 
 
 const Details: React.FC = () => {
@@ -73,21 +74,23 @@ const Details: React.FC = () => {
     }
   };
 
+  
+
   const handleCreateBoard = async () => {
     try {
       if(fileData !== null){
         const uuid = uuidv4()
+        const resizedImage = (await handleResizeImage(fileData)) as File
         const storageRef = ref(storage, `post/${user.member.nickname}/${uuid}`);
-        const uploadTask = uploadBytes(storageRef, fileData);
+        const uploadTask = uploadBytes(storageRef, resizedImage);
         const blobImage = await uploadTask;
         const downloadURL = await getDownloadURL(blobImage.ref);
         const postId = await uploadImageToServer(downloadURL, contents, uuid)
         router.push(`/my/feeds/${postId}`)
      }
-    }catch (error) {
+    }catch (error) {``
       console.error(error);
     }
-
   };
 
   const handleAddFile = () => {
@@ -99,6 +102,11 @@ const Details: React.FC = () => {
   const handleFileChange = (e:React.ChangeEvent<HTMLInputElement>) => {
     if(e.target.files !== null){
       const image = e.target.files[0]
+      const supportedFormats = ["image/jpeg", "image/png", "image/webp"];
+      if (!supportedFormats.includes(image.type)) {
+        alert("지원되지 않는 이미지 형식입니다. JPEG, PNG 또는 WEBP 형식의 이미지를 업로드해주세요.");
+        return;
+      }
       const imageURL = URL.createObjectURL(image)
       setPreviewImage(imageURL)
       setFileData(image)

--- a/pages/create/story/index.tsx
+++ b/pages/create/story/index.tsx
@@ -10,6 +10,8 @@ import html2canvas from "html2canvas";
 import axios from "axios";
 import { v4 as uuidv4} from "uuid"
 import { useSelector } from "react-redux";
+import { handleResizeImage } from "../details/handleResizeImage";
+
 
 const Story: React.FC = () => {
   const token = sessionStorage.getItem('token')
@@ -64,8 +66,9 @@ const Story: React.FC = () => {
       });
       if (blob) {
         const uuid = uuidv4()
+        const resizedImage = (await handleResizeImage(blob)) as File
         const storageRef = ref(storage, `story/${user.member.nickname}/${uuid}`);
-        const uploadTask = uploadBytes(storageRef, blob);
+        const uploadTask = uploadBytes(storageRef, resizedImage);
         const snapshot = await uploadTask;
         const downloadURL = await getDownloadURL(snapshot.ref);
         console.log("File is", downloadURL);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3760,6 +3760,11 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+react-image-file-resizer@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz#85f4ae4469fd2867d961568af660ef403d7a79af"
+  integrity sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -4557,7 +4562,6 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
-
 
 vercel@^32.5.3:
   version "32.5.3"


### PR DESCRIPTION
## Motivations 😀

- ​게시글에 업로드하는 이미지가 너무 커서 이미지 하나의 로드 시간이 3 ~ 5초정도 걸림
- 라이브러리로 간단하게 리사이징 하는법 찾음(https://github.com/onurzorluer/react-image-file-resizer)
- 이미지 리사이징 결과 크기가 절반으로 줄어듦
- 이미지 퀄리티 육안 상 문제 없음
- story page에도 쓰이기 때문에 컴포넌츠 함수로 분리
- 사이즈를 줄이니 1~3초 정도로 줄음!
  <br/>
  ​

## key Changes 🤩

- ​리사이징 함수 컴포넌츠 생성 및 적용
  <br/>
  ​

## To Reviewers 😎

- ​
![image](https://github.com/inssagram/FE/assets/105287510/5bedb931-aec9-4777-bfd9-8b97b70d400e)

오른쪽이 원본!
  <br/>
